### PR TITLE
Minor issues

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -479,8 +479,6 @@ Equally,
 acknowledging all contributions,
 however small,
 gives new contributors an early reward for taking part. 
-It can also help with the formal and informal recognition
-of labour, discussed in the following rule.
 
 Finally,
 working in the open can be great,

--- a/paper.tex
+++ b/paper.tex
@@ -273,15 +273,15 @@ to be updated, adapted, and improved incrementally,
 can free up valuable time while increasing quality.
 
 Despite the success of openness in software development and the curation of Wikipedia,
-it is an uncommon approach in academic settings.
+it is an uncommon approach in the academic instructional setting.
 Each year,
 thousands of university lecturers teach subjects ranging from first year biology,
 to graduate-level courses in Indian film.
 Some use textbooks written by one or a few authors,
 but beyond that,
 they develop and maintain their course materials in isolation.
-This is curious given that research depends critically on sharing,
-and that most researchers complain about how much time teaching takes away from research,
+Given that academic research often depends on sharing, the differing
+approach to developing pedagogical materials is interesting,
 but the sociology and psychology behind this blind spot are out of the scope of this paper.
 
 The authors have many years of experience with community-developed lessons
@@ -312,28 +312,14 @@ this is not the same as continuous improvement by a large community of contribut
 The ten simple rules that follow summarize what we have learned about doing that
 as maintainers, editors, and reviewers of lessons used by tens of thousands of people (Fig. 1, 2).
 
-\subsection*{Acknowledgments}
-
-We are grateful to everyone who provided feedback on this paper,
-including
-James Baker,
-Nathan Moore,
-Pariksheet Nanda,
-Tom Pollard,
-Byron Smith,
-and Andrew Walker.
-We are also grateful to the hundreds of people who have contributed to
-Programming Historian, Data Carpentry, Software Carpentry, and Library Carpentry
-over many years.
-
 \rulemajor{Clarify your audience}{audience}
 
 The first requirement for building lessons together is
-to know who they are being built for.
+to know whom they are being built for.
 ``Archaeology students'' is far too vague:
 are you and your collaborators thinking of
 first-year students who need an introduction to the field,
-graduate students who intend to specialize in the sub-discipline which is the lesson's focus,
+graduate students who intend to specialize in the sub-discipline that is the lesson's focus,
 or someone in between?
 If different contributors believe different things about prerequisite knowledge,
 equipment or software required,
@@ -373,10 +359,10 @@ Smaller modules are also more approachable for new contributors (\ruleref{empowe
 
 \rulemajor{Teach best practices for lesson development}{practices}
 
-Decades of pedagogical research has yielded many insights into
+Decades of pedagogical research have yielded many insights into
 how best to build and deliver lessons \cite{hlw}.
 Unfortunately,
-many college and university faculty have little or no training in education \cite{brownell},
+many college and university faculty have little or no formal training in education \cite{brownell},
 so this knowledge is rarely applied in the classroom.
 
 Our experience is that even a brief introduction to a few key practices
@@ -417,7 +403,7 @@ lessons are built by:
 This method is effective in its own right,
 but its greatest benefit is that it gives everyone a framework for collaboration.
 
-An example of how to teach these practices is Software Carpentry's instructor training program.
+An example of how to teach these practices is Software Carpentry's (\url{https://software-carpentry.org/}) instructor training program.
 First offered in 2012,
 is now a two-day course delivered both in-person and online
 \cite{lessons-learned,instructor-training,how-to-teach-programming}.
@@ -454,9 +440,10 @@ Despite their ubiquity,
 open source version control systems do not directly support review or merge
 of Microsoft Office or LibreOffice file formats,
 which raises an additional burden for newcomers \cite{jacobs}.
-Programmers may look down on Google Docs and wikis
-for their lack of pre-merge review and other capabilities,
-but their low barrier to entry make them more welcoming to newcomers.
+While Google Docs and wikis lack some capabilities, such as
+full-fledged pre-merge review (although ``suggest mode'' 
+mitigates this to some degree), 
+their low barrier to entry makes them more welcoming to newcomers.
 
 The best way to choose tools for managing lessons is
 to ask potential contributors what they are comfortable with
@@ -487,11 +474,13 @@ A key part of doing this is to create opportunities for legitimate peripheral pa
 Curating a list of small tasks that newcomers can easily tackle,
 encouraging them to give feedback on proposed changes,
 or asking them to add new exercises and tweak diagrams and references
-can all provide an on-ramp for people who might question their authority or ability to change the main body of a lesson.
+can all provide an on-ramp for people who might question their own authority or ability to change the main body of a lesson.
 Equally,
 acknowledging all contributions,
 however small,
-gives new contributors an early reward for taking part.
+gives new contributors an early reward for taking part. 
+It can also help with the formal and informal recognition
+of labour, discussed in the following rule.
 
 Finally,
 working in the open can be great,
@@ -532,10 +521,10 @@ in its releases \cite{shell2015,shell2017}.
 If lessons are being released regularly,
 automate the process
 and archive old versions in a discoverable location.
-Also make sure that everyone involved knows what ``done'' look like,
+Also make sure that everyone involved knows what ``done'' looks like,
 i.e.,
 which outstanding issues have to be addressed
-and how it has to be formatted
+and how they have to be formatted
 in order for the next release to go out.
 A simple checklist stored with the lesson materials is good enough to start,
 but as time goes by,
@@ -673,10 +662,24 @@ Every day,
 teachers all over the world spend countless hours duplicating each other's work.
 These ten rules provide an alternative:
 adopting the model of collaborative software development
-to make more robust and sustainable lessons
+to make more robust and sustainable lessons in all domains
 that can be continually improved by those who use them.
 We hope that our experiences can help others teach more
 with more impact and less effort.
+
+\subsection*{Acknowledgments}
+
+We are grateful to everyone who provided feedback on this paper,
+including
+James Baker,
+Nathan Moore,
+Pariksheet Nanda,
+Tom Pollard,
+Byron Smith,
+and Andrew Walker.
+We are also grateful to the hundreds of people who have contributed to
+Programming Historian, Data Carpentry, Software Carpentry, and Library Carpentry
+over many years.
 
 \nolinenumbers
 


### PR DESCRIPTION
Most of the smaller tweaks are pretty straightforward, but I did want to flag two that I had questions on. I figured others may want to tweak so I opened a Pull Request on the branch.

**I wasn't entirely sure of these two ones below:**

> SUGGESTION: It would be useful to provide the URL in the text for rule #3 since online best practices for lesson development circles back to online collaborative lesson development.

In this case, do we think the reviewer is referring to having a link for Software Carpentry? I inserted it. In any case, Rule 3 may be redesigned in line with issue #41. 

> SUGGESTION: In Rule #5, it would be helpful if the authors redirected to Rule #6 when discussing recognizing contributions.

I like the division that we have in Rules 5 and 6 right now, so wasn't sure about a significant reorganization (I think that'd also unbalance the text). I thought about potentially adding a sentence like 

>It can also help with the formal and informal recognition of labour, discussed in the following rule.

But I don't think we need signposting when the rules are so close to each other.