### PR TITLE
Removed a random URL

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -392,7 +392,7 @@ This method is effective in its own right,
 but its greatest benefit is that it gives everyone a framework for collaboration.
 
 An example of how to teach such pedagogical practices
-is Software Carpentry's (\url{https://software-carpentry.org/}) instructor training program.
+is Software Carpentry's instructor training program.
 First offered in 2012,
 it is now a two-day course delivered both in-person and online
 \cite{lessons-learned,instructor-training,how-to-teach-programming}.


### PR DESCRIPTION
For some reason we provided a URL for Software Carpentry under tip 3. I've removed it in this PR.

This raises two issues: 
* If we wanted to provide a URL for Software Carpentry we should have done it in the introduction and then also done the same for Programming Historian, Data Carpentry and Library Carpentry 
* Perhaps in tip 3 the URL was meant to point to the [instructor training website](https://carpentries.github.io/instructor-training/)?

URLs make me nervous (because they change all the time), which is why I haven't included these two issues in the PR. i.e. I was erring on the side of not providing URLs, but happy to put them in if people think we should. 